### PR TITLE
Update sbr_s.lua

### DIFF
--- a/gamemode/RL_BASE/sbr_s.lua
+++ b/gamemode/RL_BASE/sbr_s.lua
@@ -8,6 +8,11 @@ end
 
 
 
+--[[
+
+Ile tych timerów ;--; Nie zdziwiłbym się, gdyby to przy większej ilości graczy padło.
+
+Przeniesione do RL_LOGIN/login_s.lua
 
 setTimer( function ()
 for key, value in ipairs(getElementsByType("player")) do
@@ -28,6 +33,13 @@ if isPlayerInACL(value,"Console") then
 end
 end
 end,3000,0)
+]]--
+
+
+
+
+
+
 
 
 function addToScoreboard()


### PR DESCRIPTION
Wywalony kolejny timer, przecież to by przy 20+ graczach pewnie padło... Wywalony tzwn nie będzie już używany timer, a po prostu nadawana ranga po zalogowaniu, także jedną funkcję przeniosłem do login_s.lua.
